### PR TITLE
Fix active providers not reloading after settings changes

### DIFF
--- a/src/services/backup-service.ts
+++ b/src/services/backup-service.ts
@@ -82,15 +82,13 @@ export class BackupService {
       }
     }
 
-    // Initialize new providers
+    // Initialize new providers and update existing ones
     for (const providerName of currentProviders) {
-      if (!previousProviders.includes(providerName)) {
-        try {
-          console.info(`Initializing new provider: ${providerName}`);
-          await this.initializeProvider(providerName);
-        } catch (error) {
-          console.error(`Failed to initialize ${providerName} provider:`, error);
-        }
+      try {
+        console.info(`Initializing/Updating provider: ${providerName}`);
+        await this.initializeProvider(providerName);
+      } catch (error) {
+        console.error(`Failed to initialize ${providerName} provider:`, error);
       }
     }
   }

--- a/src/services/sync-service.ts
+++ b/src/services/sync-service.ts
@@ -58,17 +58,15 @@ export class SyncService {
           this.providers.delete(providerName);
         }
       }
+    }
 
-      // Add newly enabled providers
-      for (const providerName of currentProviders) {
-        if (!previousProviders.includes(providerName) && !this.providers.has(providerName)) {
-          const provider = ProviderRegistry.createProvider(providerName);
-          if (provider) {
-            const success = await provider.initialize(this.settings);
-            if (success) {
-              this.providers.set(providerName, provider);
-            }
-          }
+    // Add newly enabled providers and update existing ones
+    for (const providerName of currentProviders) {
+      const provider = ProviderRegistry.createProvider(providerName);
+      if (provider) {
+        const success = await provider.initialize(this.settings);
+        if (success) {
+          this.providers.set(providerName, provider);
         }
       }
     }


### PR DESCRIPTION
While configuring S3 backups, I noticed that changing the Path Prefix setting had no effect. Backups continued to be uploaded to the original location even after saving the new configuration.

After investigating, I found that settings were being saved correctly by Logseq, but active providers were not being refreshed with the updated configuration. Existing S3/WebDAV provider instances continued using stale settings until Logseq was restarted or the provider was disabled and re-enabled.

## Changes:
- Reinitialize active providers when settings change in BackupService
- Recreate and reinitialize active providers when settings change in SyncService
- Updated log messages to reflect provider updates as well as initialization

## Result:
Configuration changes such as Path Prefix, credentials, and other provider settings are now applied immediately without requiring a Logseq restart or provider toggle.

And, thanks man. This was the only and only plugin I found to sync the Logseq with my s3. With this simple fix I hope the flow can be seemless! 🫡 